### PR TITLE
Create recommendationrequest page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,10 @@ import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
+import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
+import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
+
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
@@ -47,6 +51,25 @@ function App() {
               exact
               path="/ucsbdates/create"
               element={<UCSBDatesCreatePage />}
+            />
+          </>
+        )}
+         {hasRole(currentUser, "ROLE_USER") && (
+          <>
+            <Route exact path="/recommendationrequest" element={<RecommendationRequestIndexPage />} />
+          </>
+        )}
+        {hasRole(currentUser, "ROLE_ADMIN") && (
+          <>
+            <Route
+              exact
+              path="/recommendationrequest/edit/:id"
+              element={<RecommendationRequestEditPage />}
+            />
+            <Route
+              exact
+              path="/recommendationrequest/create"
+              element={<RecommendationRequestCreatePage />}
             />
           </>
         )}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -54,9 +54,13 @@ function App() {
             />
           </>
         )}
-         {hasRole(currentUser, "ROLE_USER") && (
+        {hasRole(currentUser, "ROLE_USER") && (
           <>
-            <Route exact path="/recommendationrequest" element={<RecommendationRequestIndexPage />} />
+            <Route
+              exact
+              path="/recommendationrequest"
+              element={<RecommendationRequestIndexPage />}
+            />
           </>
         )}
         {hasRole(currentUser, "ROLE_ADMIN") && (

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -69,6 +69,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/recommendationrequest">
+                    Recommendation Request
+                  </Nav.Link>
                 </>
               ) : (
                 <></>

--- a/frontend/src/main/components/RecommendationRequests/RecommendationRequestForm.js
+++ b/frontend/src/main/components/RecommendationRequests/RecommendationRequestForm.js
@@ -124,7 +124,7 @@ function RecommendationRequestForm({
       </Form.Group>
 
       <Form.Group className="mb-3">
-        <Form.Label htmlFor="dateNeed">Date Needed(in UTC)</Form.Label>
+        <Form.Label htmlFor="dateNeeded">Date Needed(in UTC)</Form.Label>
         <Form.Control
           id="dateNeeded"
           type="datetime-local"

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function RecommendationRequestCreatePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
@@ -15,13 +15,13 @@ export default function RecommendationRequestCreatePage({ storybook = false }) {
       explanation: recommendationRequest.explanation,
       dateRequested: addZ(recommendationRequest.dateRequested),
       dateNeeded: addZ(recommendationRequest.dateNeeded),
-      done: recommendationRequest.done
+      done: recommendationRequest.done,
     },
   });
 
   const onSuccess = (recommendationrequest) => {
     toast(
-      `New restaurant Created - id: ${recommendationrequest.id} explanation: ${recommendationrequest.explanation}`,
+      `New recommendation request Created - id: ${recommendationrequest.id} requestorEmail: ${recommendationrequest.requestorEmail}`,
     );
   };
 

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
@@ -1,11 +1,52 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import RecommendationRequestForm from "main/components/RecommendationRequests/RecommendationRequestForm";
+import { Navigate } from "react-router-dom";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function RecommendationRequestCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function RecommendationRequestCreatePage({ storybook = false }) {
+  const addZ = (string) => `${string}Z`;
+  const objectToAxiosParams = (recommendationRequest) => ({
+    url: "/api/recommendationrequest/post",
+    method: "POST",
+    params: {
+      requestorEmail: recommendationRequest.requestorEmail,
+      professorEmail: recommendationRequest.professorEmail,
+      explanation: recommendationRequest.explanation,
+      dateRequested: addZ(recommendationRequest.dateRequested),
+      dateNeeded: addZ(recommendationRequest.dateNeeded),
+      done: recommendationRequest.done
+    },
+  });
+
+  const onSuccess = (recommendationrequest) => {
+    toast(
+      `New restaurant Created - id: ${recommendationrequest.id} explanation: ${recommendationrequest.explanation}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/recommendationrequest/all"], // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/recommendationrequest" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Recommendation Request</h1>
+        <RecommendationRequestForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function RecommendationRequestEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function RecommendationRequestIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/recommendationrequest/create">Create</a>
+        </p>
+        <p>
+          <a href="/recommendationrequest/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestCreatePage.stories.js
+++ b/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestCreatePage.stories.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
+
+import { RecommendationRequestFixtures } from "fixtures/recommendationRequestsFixtures";
+
+export default {
+  title: "pages/RecommendationRequest/RecommendationRequestCreatePage",
+  component: RecommendationRequestCreatePage,
+};
+
+const Template = () => <RecommendationRequestCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/recommendationrequest/post", () => {
+      return HttpResponse.json(
+        RecommendationRequestFixtures.oneRecommendationRequest,
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.js
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("RecommendationRequestCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+
+    await screen.findByText("Create page not yet implemented");
+  });
+});

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.js
@@ -1,17 +1,42 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
 describe("RecommendationRequestCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -20,15 +45,10 @@ describe("RecommendationRequestCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -37,8 +57,95 @@ describe("RecommendationRequestCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(screen.getByLabelText("Explanation")).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
+  test("on submit, makes request to backend, and redirects to /recommendationrequest", async () => {
+    const queryClient = new QueryClient();
+
+    const recommendationrequest = {
+      id: 2,
+      requestorEmail: "kevinlee@ucsb.edu",
+      professorEmail: "zmatni@ucsb.edu",
+      explanation: "Recommendation 1 ",
+      dateRequested: "2025-04-30T05:50:50",
+      dateNeeded: "2025-04-30T06:50:50",
+      done: false,
+    };
+
+    axiosMock
+      .onPost("/api/recommendationrequest/post")
+      .reply(202, recommendationrequest);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Requestor Email")).toBeInTheDocument();
+    });
+
+    const requestorEmailInput = screen.getByLabelText("Requestor Email");
+    expect(requestorEmailInput).toBeInTheDocument();
+
+    const professorEmailInput = screen.getByLabelText("Professor Email");
+    expect(professorEmailInput).toBeInTheDocument();
+
+    const explanationInput = screen.getByLabelText("Explanation");
+    expect(explanationInput).toBeInTheDocument();
+
+    const dateRequestedInput = screen.getByLabelText("Date Requested(in UTC)");
+    expect(dateRequestedInput).toBeInTheDocument();
+
+    const dateNeededInput = screen.getByLabelText("Date Needed(in UTC)");
+    expect(dateNeededInput).toBeInTheDocument();
+
+    const doneInput = screen.getByLabelText("Done");
+    expect(doneInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.change(requestorEmailInput, {
+      target: { value: "kevinlee@ucsb.edu" },
+    });
+    fireEvent.change(professorEmailInput, {
+      target: { value: "zmatni@ucsb.edu" },
+    });
+    fireEvent.change(explanationInput, {
+      target: { value: "Recommendation 1 " },
+    });
+    fireEvent.change(dateRequestedInput, {
+      target: { value: "2025-04-30T05:50:50" },
+    });
+    fireEvent.change(dateNeededInput, {
+      target: { value: "2025-04-30T06:50:50" },
+    });
+    fireEvent.change(doneInput, { target: { value: "false" } });
+
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      requestorEmail: "kevinlee@ucsb.edu",
+      professorEmail: "zmatni@ucsb.edu",
+      explanation: "Recommendation 1 ",
+      dateRequested: "2025-04-30T05:50:50.000Z",
+      dateNeeded: "2025-04-30T06:50:50.000Z",
+      done: "false",
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toBeCalledWith(
+      "New recommendation request Created - id: 2 requestorEmail: kevinlee@ucsb.edu",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/recommendationrequest" });
   });
 });

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestEditPage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestEditPage.test.js
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("RecommendationRequestEditPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await screen.findByText("Edit page not yet implemented");
+  });
+});

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.js
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("RecommendationRequestIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Index page not yet implemented");
+
+    // assert
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #31 

Merge after: #83 

In this PR, we replace the placeholder create with a working create page for recommendation request

Storybook: https://68108f26d5507438df05333b-namypvqxjt.chromatic.com/?path=/story/components-helprequest-helprequestform--create

To test: 
1. login to this dokku instance: https://team02-dev-hienhuynh2026.dokku-05.cs.ucsb.edu/
2. Navigate to the create page for the recommendation request
3. Fill in the fields
4. Click create 
5. Check the api/recommendationrequest/all endpoint with Swagger to see if the new record is in the database  